### PR TITLE
Add Fork CMS

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,6 +55,10 @@
                             <td><a href="https://github.com/cakephp/cakephp/wiki/4.0-Roadmap#require-at-least-php-71">CakePHP 4.0</a></td>
                             <td>Early 2018</td>
                         </tr>
+                        <tr>
+                            <td><a href="https://github.com/forkcms/forkcms/blob/master/UPGRADE_5.0.md#spoon-library-has-been-updated-to-300">Fork CMS 5</a></td>
+                            <td>August 2017</td>
+                        </tr>
                     </table>
 
                     <br>


### PR DESCRIPTION
With the release of version 5.0.0 Fork CMS bumped the required php version to 7.1