### PR TITLE
Fix Spryker date as done per Jan 2018

### DIFF
--- a/_data/projects.yaml
+++ b/_data/projects.yaml
@@ -51,8 +51,8 @@
 
 - name: Spryker
   url: https://academy.spryker.com/what_s_new/releases/release_notes_august_1_2017.html#announcements
-  when: ~ 2018
-  done: false
+  when: Jan 2018
+  done: true
 
 - name: Laravel 5.6
   url: https://github.com/laravel/framework/pull/21995


### PR DESCRIPTION
Partially reverts the a bit too eager one @ https://github.com/TomasVotruba/gophp71.org/commit/eb9fb5befb0e6aac6a81aaa872bbdfff8b78dbc7#r27068927

Please see
- https://github.com/spryker/spryker-core
- all splits of https://github.com/spryker/ org.

etc
I made sure that every composer json states this now clearly :)